### PR TITLE
Improve devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 #    docker build .devcontainer
 # And note, it'll cache the layers, which means if you're just messing around with the last few lines, it'll be fast.
 
-FROM mcr.microsoft.com/devcontainers/ruby:3.3
+FROM ghcr.io/rails/devcontainer/images/ruby:3.3.0
 
 ADD https://github.com/Enter-tainer/typstyle/releases/download/v0.11.28/typstyle-linux-arm64 /usr/bin/typstyle
 RUN chmod +x /usr/bin/typstyle
@@ -30,11 +30,3 @@ cp source-sans-2.020R-ro-1.075R-it/OTF/*.otf /usr/local/share/fonts
 fc-cache -f -v
 rm -rf $TEMP_DIR
 EOF
-
-# Install the Ruby LSP server here so that it's available in the container in time for the VSCode extension to start
-RUN gem install bundler ruby-lsp debug 
-
-# Install our gem for converting Ruby flightplans from the git repo
-RUN git clone https://github.com/Better-Conversations/ruby-flightplans.git
-RUN cd ruby-flightplans && gem build ./bcf-flightplans.gemspec --output=bcf-flightplans.gem && gem install ./bcf-flightplans.gem
-RUN rm -rf ./bcf-flightplans

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,23 +2,23 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/ruby
 {
 	"name": "Ruby",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
+	
+	// We build our own docker container to include additional tools and fonts.
+	// This is based off of the rails ruby devcontainer as the MS one uses rvm + rbenv in weird ways.
+	// This was the cause of the BUNDLE_* env variables needing to be set.
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/git:1": {},
 		"ghcr.io/michidk/devcontainers-features/typst:1": {}
 	},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "BUNDLE_PATH=~/.bundle bundle install",
-
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
@@ -26,28 +26,27 @@
 				"nvarner.typst-lsp",
 				"mathematic.vscode-pdf",
 				"Gruntfuggly.todo-tree",
-				"ms-azuretools.vscode-docker"
+				"ms-azuretools.vscode-docker",
+				"eamodio.gitlens"
 			],
-				// All of these settings are scoped only to the Ruby language
-				"[ruby]": {
-					"editor.defaultFormatter": "Shopify.ruby-lsp", // Use the Ruby LSP as the default formatter
-					"editor.formatOnSave": true, // Format files automatically when saving
-					"editor.tabSize": 2, // Use 2 spaces for indentation
-					"editor.insertSpaces": true, // Use spaces and not tabs for indentation
-					"editor.semanticHighlighting.enabled": true, // Enable semantic highlighting
-					"editor.formatOnType": true // Enable formatting while typing
-				}
+			// All of these settings are scoped only to the Ruby language
+			"[ruby]": {
+				"editor.defaultFormatter": "Shopify.ruby-lsp", // Use the Ruby LSP as the default formatter
+				"editor.formatOnSave": true, // Format files automatically when saving
+				"editor.tabSize": 2, // Use 2 spaces for indentation
+				"editor.insertSpaces": true, // Use spaces and not tabs for indentation
+				"editor.semanticHighlighting.enabled": true, // Enable semantic highlighting
+				"editor.formatOnType": true // Enable formatting while typing
 			}
-		},
-
+		}
+	},
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 
 	// Set environment variables to ensure Ruby can find the gems
 	"remoteEnv": {
-		"BUNDLE_PATH": "${containerWorkspaceFolder}/.bundle",
-		"GEM_HOME": "${containerWorkspaceFolder}/.bundle",
+		// "BUNDLE_PATH": "${containerWorkspaceFolder}/.bundle",
+		// "GEM_HOME": "${containerWorkspaceFolder}/.bundle",
 		// "PATH": "${containerWorkspaceFolder}/.bundle/bin:${PATH}"
 	}
 }
-

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,10 +43,5 @@
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"
 
-	// Set environment variables to ensure Ruby can find the gems
-	"remoteEnv": {
-		// "BUNDLE_PATH": "${containerWorkspaceFolder}/.bundle",
-		// "GEM_HOME": "${containerWorkspaceFolder}/.bundle",
-		// "PATH": "${containerWorkspaceFolder}/.bundle/bin:${PATH}"
-	}
+	"remoteEnv": {}
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Better-Conversations/ruby-flightplans.git
-  revision: 3e6b8607ed62688b1468c5bd9d8db8ca0d26f903
+  revision: f61588710e4be5760fee8a303030a3482896a343
   specs:
     bcf-flightplans (0.2.0)
       redcarpet (~> 3.6)

--- a/bin/render-pdf
+++ b/bin/render-pdf
@@ -1,8 +1,6 @@
 #!/usr/bin/env ruby
 
 # Setup bundler so we can require gems
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-ENV['BUNDLE_PATH'] ||= File.expand_path('../.bundle', __dir__)
 require 'bundler/setup'
 
 require 'bcf/flightplans'


### PR DESCRIPTION
- Move to using the rails ruby devcontainer as a base.
- Remove `BUNDLE_` environment variables in scripts as these are no longer needed