### PR TITLE
Fix release artifact naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           # Create release with all course artifacts
           gh release create ${{ github.ref_name }} \
-            json-outputs-experience-${{ env.COURSE_VERSION }}.zip \
+            json-outputs-bc-${{ env.COURSE_VERSION }}.zip \
             json-outputs-bc-ai-${{ env.COURSE_VERSION }}.zip \
             --title ${{ github.ref_name }}
         env:

--- a/bin/zip-outputs
+++ b/bin/zip-outputs
@@ -2,11 +2,15 @@
 
 # Check if a course name was provided
 if [ -z "$2" ]; then
-  # No course specified, zip all courses separately
-  zip -r json-outputs-experience-$1.zip json-outputs/experience-$1
-  zip -r json-outputs-bc-ai-$1.zip json-outputs/bc-ai-$1
+  # No specific course supplied. Zip any directories produced by
+  # `bin/make-release` that match the version suffix.
+  for dir in json-outputs/*-$1; do
+    [ -d "$dir" ] || continue
+    base=$(basename "$dir")
+    zip -r "json-outputs-$base.zip" "$dir"
+  done
 else
-  # Zip specific course
+  # Zip only the requested course directory
   course_name=$2
-  zip -r json-outputs-$course_name-$1.zip json-outputs/$course_name-$1
+  zip -r "json-outputs-${course_name}-$1.zip" "json-outputs/${course_name}-$1"
 fi


### PR DESCRIPTION
## Summary
- zip artifacts for every release directory
- adjust artifact names in the release workflow

## Testing
- `./bin/lint-flight-plans` *(fails: rbenv: version `3.3.0` is not installed)*
- Created dummy release directories and ran `./bin/zip-outputs test123`