### PR TITLE
Fix pre_flight comment

### DIFF
--- a/source/shared/common_blocks.rb
+++ b/source/shared/common_blocks.rb
@@ -10,7 +10,7 @@ module BCF
     end
 
     module CommonBlocks
-      # Call this with `block BCF::FlightPlans::CommonBlocks::preflight_block(25)`
+      # Call this with `block BCF::FlightPlans::CommonBlocks::pre_flight(25)`
       def self.pre_flight(length_value)
         Block.build do
           length(length_value)


### PR DESCRIPTION
## Summary
- update comment with the correct `pre_flight` method name

## Testing
- `bin/lint-flight-plans` *(fails: rbenv version `3.3.0` is not installed)*